### PR TITLE
Update Jira Version to 9.0.0 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@ http://maven.apache.org/POM/4.0.0 ">
     </build>
 
     <properties>
-        <jira.version>7.0.2</jira.version>
+        <jira.version>9.0.0</jira.version>
         <amps.version>5.1.10</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <testkit.version>5.2.26</testkit.version>


### PR DESCRIPTION
This pull request fixes #3 by updating the Jira version from 7.0.2 to 9.0.0 in the `pom.xml` file. This change is part of the effort to align the codebase with the latest Jira release 9.x, as outlined in the issue. The update ensures compatibility with newer features and security improvements introduced in Jira 9.x. However, it's important to verify that this version upgrade does not introduce any breaking changes or compatibility issues with other dependencies specified in the `pom.xml`. Further testing and validation are recommended to ensure seamless integration.